### PR TITLE
If no position data given, leave layout to Pashua

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -22,8 +22,6 @@ func main() {
 			"tf": pashua.PashuaTextField{
 				Label:   "Gib was ein",
 				Default: "42",
-				Width:   100,
-				Y:       20,
 			},
 			"cb": pashua.PashuaCombobox{
 				Label:          "My combobox label",
@@ -31,7 +29,6 @@ func main() {
 				Width:          220,
 				Tooltip:        "Choose from the list",
 				CompletionMode: pashua.CaseInsensitive,
-				Y:              60,
 			},
 			"dt": pashua.PashuaDate{
 				Label:   "TickTock",
@@ -40,7 +37,6 @@ func main() {
 				UseTime: false,
 				Default: "2020-07-04",
 				Textual: false,
-				Y:       120,
 			},
 			"ok": pashua.PashuaDefaultButton{
 				Label:   "OK",

--- a/pashua.go
+++ b/pashua.go
@@ -29,6 +29,14 @@ const (
 	Mini             = "mini"
 )
 
+// Position can be used to set an element's absolute position or move it relatively
+type Position struct {
+	X    int
+	Y    int
+	RelX int
+	RelY int
+}
+
 // PashuaButton is a structure that holds all information for a PashuaButton
 type PashuaButton struct {
 	Label    string
@@ -51,10 +59,7 @@ type PashuaCheckbox struct {
 	Default  bool
 	Disabled bool
 	Tooltip  string
-	X        int
-	Y        int
-	RelX     int
-	RelY     int
+	Position
 }
 
 // PashuaCombobox is a structure that holds all information for a PashuaCombobox
@@ -68,10 +73,7 @@ type PashuaCombobox struct {
 	Disabled       bool
 	Tooltip        string
 	Width          int
-	X              int
-	Y              int
-	RelX           int
-	RelY           int
+	Position
 }
 
 // PashuaDate is a structure that holds all information for a PashuaDate
@@ -83,8 +85,7 @@ type PashuaDate struct {
 	Default  string
 	Disabled bool
 	Tooltip  string
-	X        int
-	Y        int
+	Position
 }
 
 // PashuaDefaultButton is a structure that holds all information for a PashuaDefaultButton
@@ -105,10 +106,7 @@ type PashuaImage struct {
 	MaxHeight int
 	UpScale   bool
 	Tooltip   string
-	X         int
-	Y         int
-	RelX      int
-	RelY      int
+	Position
 }
 
 // PashuaOpenBrowser is a structure that holds all information for a PashuaOpenBrowser
@@ -119,10 +117,7 @@ type PashuaOpenBrowser struct {
 	Filetype    string
 	Placeholder string
 	Mandatory   bool
-	X           int
-	Y           int
-	RelX        int
-	RelY        int
+	Position
 }
 
 // PashuaPassword is a structure that holds all information for a PashuaPassword
@@ -133,10 +128,7 @@ type PashuaPassword struct {
 	Mandatory bool
 	Tooltip   string
 	Width     int
-	X         int
-	Y         int
-	RelX      int
-	RelY      int
+	Position
 }
 
 // PashuaPopup is a structure that holds all information for a PashuaPopup
@@ -148,10 +140,7 @@ type PashuaPopup struct {
 	Tooltip   string
 	Mandatory bool
 	Width     int
-	X         int
-	Y         int
-	RelX      int
-	RelY      int
+	Position
 }
 
 // PashuaRadioButton is a structure that holds all information for a PashuaRadioButton
@@ -162,10 +151,7 @@ type PashuaRadioButton struct {
 	Disabled  bool
 	Tooltip   string
 	Mandatory bool
-	X         int
-	Y         int
-	RelX      int
-	RelY      int
+	Position
 }
 
 // PashuaSaveBrowser is a structure that holds all information for a PashuaSaveBrowser
@@ -176,10 +162,7 @@ type PashuaSaveBrowser struct {
 	Filetype    string
 	Placeholder string
 	Mandatory   bool
-	X           int
-	Y           int
-	RelX        int
-	RelY        int
+	Position
 }
 
 // PashuaText is a structure that holds all information for a PashuaText
@@ -188,10 +171,7 @@ type PashuaText struct {
 	Text    string
 	Tooltip string
 	Width   int
-	X       int
-	Y       int
-	RelX    int
-	RelY    int
+	Position
 }
 
 // PashuaTextBox is a structure that holds all information for a PashuaTextBox
@@ -205,10 +185,7 @@ type PashuaTextBox struct {
 	Disabled  bool
 	Width     int
 	Height    int
-	X         int
-	Y         int
-	RelX      int
-	RelY      int
+	Position
 }
 
 // PashuaTextField is a structure that holds all information for a PashuaTextField
@@ -219,10 +196,7 @@ type PashuaTextField struct {
 	Mandatory bool
 	Disabled  bool
 	Width     int
-	X         int
-	Y         int
-	RelX      int
-	RelY      int
+	Position
 }
 
 // PashuaComponents is type for th elist of components contained in a Pashua window
@@ -317,6 +291,23 @@ func RunPashuaWithStruct(pashuaWindow *PashuaWindow, pashuaPath string) (map[str
 	return RunPashua(configString, pashuaPath)
 }
 
+func appendPositionalAttributes(def []string, name string, txt *Position) []string {
+	if "0" != getFieldValue(txt.X) {
+		def = append(def, name+".x="+getFieldValue(txt.X))
+	}
+	if "0" != getFieldValue(txt.Y) {
+		def = append(def, name+".y="+getFieldValue(txt.Y))
+	}
+	if "0" != getFieldValue(txt.RelX) {
+		def = append(def, name+".relx="+getFieldValue(txt.RelX))
+	}
+	if "0" != getFieldValue(txt.RelY) {
+		def = append(def, name+".rely="+getFieldValue(txt.RelY))
+	}
+
+	return def
+}
+
 // parsePashuaOutput takes a list of lines and
 // converts key=value pairs to a map and
 // skips empty lines of lines without an "="
@@ -399,8 +390,7 @@ func (btn *PashuaDate) ToString(key string) string {
 	result = append(result, key+".date="+getFieldValue(btn.UseDate))
 	result = append(result, key+".time="+getFieldValue(btn.UseTime))
 	result = append(result, key+".textual="+getFieldValue(btn.Textual))
-	result = append(result, key+".x="+getFieldValue(btn.X))
-	result = append(result, key+".y="+getFieldValue(btn.Y))
+	result = appendPositionalAttributes(result, key, &btn.Position)
 	return strings.Join(result, "\n")
 }
 
@@ -426,10 +416,7 @@ func (txt *PashuaCheckbox) ToString(key string) string {
 	result = append(result, key+".default="+getFieldValue(txt.Default))
 	result = append(result, key+".disabled="+getFieldValue(txt.Disabled))
 	result = append(result, key+".tooltip="+getFieldValue(txt.Tooltip))
-	result = append(result, key+".x="+getFieldValue(txt.X))
-	result = append(result, key+".y="+getFieldValue(txt.Y))
-	result = append(result, key+".relx="+getFieldValue(txt.RelX))
-	result = append(result, key+".rely="+getFieldValue(txt.RelY))
+	result = appendPositionalAttributes(result, key, &txt.Position)
 	return strings.Join(result, "\n")
 }
 
@@ -440,10 +427,7 @@ func (txt *PashuaCombobox) ToString(key string) string {
 	result = append(result, key+".tooltip="+getFieldValue(txt.Tooltip))
 	result = append(result, key+".width="+getFieldValue(txt.Width))
 	result = append(result, key+".rows="+getFieldValue(txt.Rows))
-	result = append(result, key+".x="+getFieldValue(txt.X))
-	result = append(result, key+".y="+getFieldValue(txt.Y))
-	result = append(result, key+".relx="+getFieldValue(txt.RelX))
-	result = append(result, key+".rely="+getFieldValue(txt.RelY))
+	result = appendPositionalAttributes(result, key, &txt.Position)
 	result = append(result, key+".placeholder="+getFieldValue(txt.Placeholder))
 	result = append(result, key+".mandatory="+getFieldValue(txt.Mandatory))
 	result = append(result, key+".completion="+getFieldValue(txt.CompletionMode))
@@ -463,10 +447,7 @@ func (txt *PashuaImage) ToString(key string) string {
 	result = append(result, key+".maxwidth="+getFieldValue(txt.MaxWidth))
 	result = append(result, key+".maxheight="+getFieldValue(txt.MaxHeight))
 	result = append(result, key+".upscale="+getFieldValue(txt.UpScale))
-	result = append(result, key+".x="+getFieldValue(txt.X))
-	result = append(result, key+".y="+getFieldValue(txt.Y))
-	result = append(result, key+".relx="+getFieldValue(txt.RelX))
-	result = append(result, key+".rely="+getFieldValue(txt.RelY))
+	result = appendPositionalAttributes(result, key, &txt.Position)
 	return strings.Join(result, "\n")
 }
 
@@ -478,10 +459,7 @@ func (txt *PashuaOpenBrowser) ToString(key string) string {
 	result = append(result, key+".width="+getFieldValue(txt.Width))
 	result = append(result, key+".mandatory="+getFieldValue(txt.Mandatory))
 	result = append(result, key+".placeholder="+getFieldValue(txt.Placeholder))
-	result = append(result, key+".x="+getFieldValue(txt.X))
-	result = append(result, key+".y="+getFieldValue(txt.Y))
-	result = append(result, key+".relx="+getFieldValue(txt.RelX))
-	result = append(result, key+".rely="+getFieldValue(txt.RelY))
+	result = appendPositionalAttributes(result, key, &txt.Position)
 	return strings.Join(result, "\n")
 }
 
@@ -493,10 +471,7 @@ func (txt *PashuaSaveBrowser) ToString(key string) string {
 	result = append(result, key+".width="+getFieldValue(txt.Width))
 	result = append(result, key+".mandatory="+getFieldValue(txt.Mandatory))
 	result = append(result, key+".placeholder="+getFieldValue(txt.Placeholder))
-	result = append(result, key+".x="+getFieldValue(txt.X))
-	result = append(result, key+".y="+getFieldValue(txt.Y))
-	result = append(result, key+".relx="+getFieldValue(txt.RelX))
-	result = append(result, key+".rely="+getFieldValue(txt.RelY))
+	result = appendPositionalAttributes(result, key, &txt.Position)
 	return strings.Join(result, "\n")
 }
 
@@ -508,10 +483,7 @@ func (txt *PashuaPassword) ToString(key string) string {
 	result = append(result, key+".default="+getFieldValue(txt.Default))
 	result = append(result, key+".disabled="+getFieldValue(txt.Disabled))
 	result = append(result, key+".mandatory="+getFieldValue(txt.Mandatory))
-	result = append(result, key+".x="+getFieldValue(txt.X))
-	result = append(result, key+".y="+getFieldValue(txt.Y))
-	result = append(result, key+".relx="+getFieldValue(txt.RelX))
-	result = append(result, key+".rely="+getFieldValue(txt.RelY))
+	result = appendPositionalAttributes(result, key, &txt.Position)
 	return strings.Join(result, "\n")
 }
 
@@ -523,10 +495,7 @@ func (txt *PashuaPopup) ToString(key string) string {
 	result = append(result, key+".default="+getFieldValue(txt.Default))
 	result = append(result, key+".disabled="+getFieldValue(txt.Disabled))
 	result = append(result, key+".mandatory="+getFieldValue(txt.Mandatory))
-	result = append(result, key+".x="+getFieldValue(txt.X))
-	result = append(result, key+".y="+getFieldValue(txt.Y))
-	result = append(result, key+".relx="+getFieldValue(txt.RelX))
-	result = append(result, key+".rely="+getFieldValue(txt.RelY))
+	result = appendPositionalAttributes(result, key, &txt.Position)
 	for _, k := range txt.Option {
 		result = append(result, key+".option="+getFieldValue(k))
 	}
@@ -540,10 +509,7 @@ func (txt *PashuaRadioButton) ToString(key string) string {
 	result = append(result, key+".default="+getFieldValue(txt.Default))
 	result = append(result, key+".disabled="+getFieldValue(txt.Disabled))
 	result = append(result, key+".mandatory="+getFieldValue(txt.Mandatory))
-	result = append(result, key+".x="+getFieldValue(txt.X))
-	result = append(result, key+".y="+getFieldValue(txt.Y))
-	result = append(result, key+".relx="+getFieldValue(txt.RelX))
-	result = append(result, key+".rely="+getFieldValue(txt.RelY))
+	result = appendPositionalAttributes(result, key, &txt.Position)
 	for _, k := range txt.Option {
 		result = append(result, key+".option="+getFieldValue(k))
 	}
@@ -557,10 +523,7 @@ func (txt *PashuaText) ToString(key string) string {
 	s = strings.Replace(s, "\n", "[return]", -1)
 	result = append(result, key+".text="+s)
 	result = append(result, key+".tooltip="+txt.Tooltip)
-	result = append(result, key+".x="+getFieldValue(txt.X))
-	result = append(result, key+".y="+getFieldValue(txt.Y))
-	result = append(result, key+".relx="+getFieldValue(txt.RelX))
-	result = append(result, key+".rely="+getFieldValue(txt.RelY))
+	result = appendPositionalAttributes(result, key, &txt.Position)
 	return strings.Join(result, "\n")
 }
 
@@ -581,10 +544,7 @@ func (txt *PashuaTextBox) ToString(key string) string {
 	}
 	result = append(result, key+".fonttype="+s)
 	result = append(result, key+".fontsize="+getFieldValue(txt.FontSize))
-	result = append(result, key+".x="+getFieldValue(txt.X))
-	result = append(result, key+".y="+getFieldValue(txt.Y))
-	result = append(result, key+".relx="+getFieldValue(txt.RelX))
-	result = append(result, key+".rely="+getFieldValue(txt.RelY))
+	result = appendPositionalAttributes(result, key, &txt.Position)
 	return strings.Join(result, "\n")
 }
 
@@ -595,10 +555,7 @@ func (txt *PashuaTextField) ToString(key string) string {
 	result = append(result, key+".tooltip="+txt.Tooltip)
 	result = append(result, key+".disabled="+getFieldValue(txt.Disabled))
 	result = append(result, key+".mandatory="+getFieldValue(txt.Mandatory))
-	result = append(result, key+".x="+getFieldValue(txt.X))
-	result = append(result, key+".y="+getFieldValue(txt.Y))
-	result = append(result, key+".relx="+getFieldValue(txt.RelX))
-	result = append(result, key+".rely="+getFieldValue(txt.RelY))
+	result = appendPositionalAttributes(result, key, &txt.Position)
 	return strings.Join(result, "\n")
 }
 


### PR DESCRIPTION
In my eyes, one of the most appealing features of Pashua is that it if you don’t want to, you don’t have to bother with layout, positions and distances – just list the elements in the required order, and Pashua will do the rest.

Having said that: this approach does not work with the way the binding is written right now. This is due to the fact, that the four positional attributes `x`, `y`, `relx`, `rely` are _always_ passed to Pashua, and if not specified in the code, they are “zeroed“. Which, in combination, results in the user having to specifiy positions, as otherwise, all the elements will overlap.

My suggestion therefore: introduce a `Position` struct, extract the position handling code to a function and only include attributes that are really used. Just for the matter of demonstration, I removed the positional attributes from `example.go`. But of course, absolute or relative attributes can be used.

Remark 1: as you can see, in `appendPositionalAttributes`, a check for “0” is performed. This poses a problem if a user wants to use the x/y position `0`. But this should be simple to work around, by introducing a magic number as an “undefined” indicator.

Remark 2: the struct `PashuaDate` did not include `RelX` and `RelY`. This surprised me, but I found that this is perfectly consistent with the documentation – except that the documentation is wrong here. The `date` element _does_ support relative x and y, as almost any other element does.   I’ll update the docs shortly.

Final disclaimer: my Go knowledge is very, very limited.